### PR TITLE
Better mobile friendliness in modal, tablet screen width changed to 850px universally

### DIFF
--- a/components/ImageSlider/ImageSlider.js
+++ b/components/ImageSlider/ImageSlider.js
@@ -22,9 +22,17 @@ const ImageSlider = props => {
     return () => document.removeEventListener('keydown', handleKeyPress);
   }, [activeImageIndex]);
 
-  const renderControls = () => {
-    const prevClassNames = [ styles.button, styles.buttonPrev ];
-    const nextClassNames = [ styles.button, styles.buttonNext ];
+  const handleClick = (e, increment) => {
+    e.preventDefault();
+    setActiveImageIndex(prevIndex => prevIndex + increment);
+  };
+
+  const renderControls = (isMobile = false) => {
+    const prevClassNames = [ styles.buttonPrev ];
+    const nextClassNames = [ styles.buttonNext ];
+
+    prevClassNames.push(isMobile ? styles.buttonMobile : styles.button);
+    nextClassNames.push(isMobile ? styles.buttonMobile : styles.button);
 
     if(activeImageIndex === 0) {
       prevClassNames.push(styles.hidden)
@@ -35,11 +43,11 @@ const ImageSlider = props => {
     }
 
     return <>
-        <button className={prevClassNames.join(' ')} onClick={() => setActiveImageIndex(prevIndex => prevIndex - 1)}>
+        <button className={prevClassNames.join(' ')} onClick={e => handleClick(e, -1)}>
           <i className="material-icons">navigate_before</i>
         </button>
 
-        <button className={nextClassNames.join(' ')} onClick={() => setActiveImageIndex(prevIndex => prevIndex + 1)}>
+        <button className={nextClassNames.join(' ')} onClick={e => handleClick(e, 1)}>
           <i className="material-icons">navigate_next</i>
         </button>
     </>;
@@ -49,6 +57,10 @@ const ImageSlider = props => {
     <div className={styles.imageSlider}>
       <img className={styles.image} src={images[activeImageIndex].src} alt={images[activeImageIndex].alt}/>
       { renderControls() }
+
+      <div className={styles.mobileControls}>
+        { renderControls(true) }
+      </div>
     </div>
   );
 };

--- a/components/ImageSlider/ImageSlider.js
+++ b/components/ImageSlider/ImageSlider.js
@@ -23,7 +23,7 @@ const ImageSlider = props => {
   }, [activeImageIndex]);
 
   const handleClick = (e, increment) => {
-    e.preventDefault();
+    e.preventDefault(); // to make quick tapping on phone not cause a zoom-in
     setActiveImageIndex(prevIndex => prevIndex + increment);
   };
 

--- a/components/ImageSlider/ImageSlider.module.css
+++ b/components/ImageSlider/ImageSlider.module.css
@@ -54,7 +54,7 @@ button.hidden {
   display: none;
 }
 
-@media(max-width: 768px) {
+@media(max-width: 850px) {
   .button {
     display: none;
   }

--- a/components/ImageSlider/ImageSlider.module.css
+++ b/components/ImageSlider/ImageSlider.module.css
@@ -15,7 +15,7 @@
   visibility: visible;
 }
 
-.button.hidden {
+button.hidden {
   display: none;
 }
 
@@ -50,10 +50,37 @@
   right: 0;
 }
 
+.mobileControls {
+  display: none;
+}
+
 @media(max-width: 768px) {
+  .button {
+    display: none;
+  }
+
   .image {
     width: 400px;
     height: 270px;
+  }
+
+  .mobileControls {
+    display: block;
+    height: 42px;
+    width: 100%;
+    margin: 1rem 0;
+    position: relative;
+  }
+
+  .buttonMobile {
+    position: absolute;
+    top: 0;
+    border: 1px solid #000;
+    background-color: #fff;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    padding: 0.5rem;
   }
 }
 

--- a/components/Modal/Modal.js
+++ b/components/Modal/Modal.js
@@ -28,7 +28,7 @@ const Modal = props => {
       </button>
       { props.children }
       <button className={styles.closeButtonMobile} onClick={onClose}>
-        Close Project
+        Close
       </button>
     </div>
   </>;

--- a/components/Modal/Modal.module.css
+++ b/components/Modal/Modal.module.css
@@ -46,6 +46,8 @@
     padding: 0.5rem 1rem;
     cursor: pointer;
     font-size: 1rem;
+    border: 1px solid #000;
+    cursor: pointer;
   }
 }
 

--- a/components/Modal/Modal.module.css
+++ b/components/Modal/Modal.module.css
@@ -35,7 +35,7 @@
   display: none;
 }
 
-@media(max-width: 768px) {
+@media(max-width: 850px) {
   .closeButton {
     display: none;
   }

--- a/components/Projects/ProjectDetail/ProjectDetail.module.css
+++ b/components/Projects/ProjectDetail/ProjectDetail.module.css
@@ -6,6 +6,7 @@
 
 .projectName {
   font-size: 2rem;
+  text-align: center;
 }
 
 .description {
@@ -20,6 +21,8 @@
   width: 100%;
   display: flex;
   justify-content: space-evenly;
+  margin: 1rem 0;
+  margin-bottom: 0;
 }
 
 .links a {

--- a/components/TableOfContents/TableOfContentsMenu/TableOfContentsMenu.module.css
+++ b/components/TableOfContents/TableOfContentsMenu/TableOfContentsMenu.module.css
@@ -41,7 +41,7 @@
   cursor: pointer;
 }
 
-@media(max-width: 768px) {
+@media(max-width: 850px) {
   .menuExpandButton:hover .chapterTitle {
     display: none;
   }


### PR DESCRIPTION
ImageSlider now has permanently visible (i.e., not hover-state visible) navigation controls in 850px or lower screen widths. Spacing in the modal / ProjectDetail component is better in mobile / tablet views. Close button in mobile modal now just says "Close" instead of "Close Project"